### PR TITLE
(maint) adds cond logic in Gemfile for new octokit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,11 @@
 source 'https://rubygems.org'
 
-gem 'octokit'
+if RUBY_VERSION <= '2.0.0'
+  gem 'octokit', '4.3.0'
+else
+  gem 'octokit'
+end
+
 gem 'gruff'
 
 group 'development' do


### PR DESCRIPTION
octokit 4.4.0 (released yesterday), requires Ruby 2.0.0 or higher. The PR Metrics job is broken because of this which means no [PR table](https://jenkins-modules.puppetlabs.com/view/Metrics/job/module-metrics_metrics_maint_pr-metrics/PR_Metrics_for_PE/) for PR triage. 
