### PR TITLE
(maint) add labels to owner column

### DIFF
--- a/pr_review_list.rb
+++ b/pr_review_list.rb
@@ -72,6 +72,12 @@ repos.each do |repo|
     row[:pr] = pr[:pull].number
     row[:age] = ((Time.now - pr[:pull].created_at) / 60 / 60 / 24).round
     row[:owner] = pr[:pull].user.login
+    if util.client.organization_member?("puppetlabs", pr[:pull].user.login)
+      row[:owner] += " <span class='label label-warning'>puppet</span>"
+    end
+    if util.client.organization_member?("voxpupuli", pr[:pull].user.login)
+      row[:owner] += " <span class='label label-primary'>vox</span>"
+    end
     row[:title] = pr[:pull].title
 
     if pr[:issue_comments].size > 0 


### PR DESCRIPTION
- helps on PR triage to recognize puppet and voxpupuli members when combing the list
- uses available bootstrap classes