### PR TITLE
(maint) - Remove reboot module from list

### DIFF
--- a/octokit_utils.rb
+++ b/octokit_utils.rb
@@ -26,7 +26,6 @@ class OctokitUtils
     'package',
     'postgresql',
     'puppet_conf',
-    'reboot',
     'resource',
     'satellite_pe_tools',
     'service',


### PR DESCRIPTION
This is not managed by the Modules team any longer.