### PR TITLE
removed autogenerated projects

### DIFF
--- a/octokit_utils.rb
+++ b/octokit_utils.rb
@@ -8,10 +8,8 @@ class OctokitUtils
   SUPPORTED_MODULES = [
     'accounts',
 'acl',
-'amazon_aws',
 'apache',
 'apt',
-'azure_arm',
 'bootstrap',
 'chocolatey',
 'concat',


### PR DESCRIPTION
removed 2 projects from the supported modules list. These 2 were generated by autogenic. They can have issues, but can't have PRs. All the related issues will be fixed in autogenic project

amazon_aws
zure_arm