### PR TITLE
Sort Tags in Semver Order

### DIFF
--- a/octokit_utils.rb
+++ b/octokit_utils.rb
@@ -353,7 +353,16 @@ class OctokitUtils
     end
 
     tags ||= client.tags(repo)
-    tags.select {|tag| tag[:name] =~ /#{regex}/}
+
+    sort_client_tags tags
+  end
+
+  def sort_client_tags(tags)
+    pattern = /(\d+\.\d+\.\d+)/
+
+    numeric_tags = tags.select { |t| t.name.match(pattern) }
+
+    numeric_tags.sort_by { |t| Gem::Version.new(t.name.match(pattern)) }.reverse!
   end
 
   def ref_from_tag(tag)


### PR DESCRIPTION
Prior to this change tags were sorted based on their string data type
sort order. This change attempts to sort tags based on their semver
version ordering. It will strip any letters from both ends of the
version number and can only sort versions that follow the x.y.z version
scheme. Any deviation could result in mis-sorts or errors.