### PR TITLE
Use a patched gruff to install current rmagick

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,10 @@ else
   gem 'octokit'
 end
 
-gem 'gruff'
+# gruff appears to have gone dormant. This allows it to install with current
+# rmagick, which fixes an imagemagick@6 pkg-config bug.
+# https://github.com/topfunky/gruff/pull/186
+gem 'gruff', github: "Watson1978/gruff", branch: "rmagick"
 
 group 'development' do
   gem 'pry'


### PR DESCRIPTION
gruff appears to have gone dormant. It pins to an old version of rmagick
that has an install bug with imagemagick@6 installed via Homebrew.
This fork just fixes that pin.

https://github.com/topfunky/gruff/pull/186