### PR TITLE
Adds ability to manage labels on single repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ Labels
 -------
 
 Puts a set of labels into each repository. Creates them in a non destructive way.
+By default, it will run against all repositories in `modules.json`, but you can
+run it on a single module in a few ways:
+
+* `--repo <namespace/repo>`
+* `--repo` (uses the first found of the `upstream` or `origin` remotes of CWD)
+* `--remote <name>` (uses the url of the remote name passed in the CWD)
+* `--file <filename.json>` (see `modules.json` for format)
 
 Npc
 ----

--- a/labels.rb
+++ b/labels.rb
@@ -4,31 +4,67 @@
 require 'optparse'
 require_relative 'octokit_utils'
 
+def primary_remote
+  ['upstream', 'origin'].map do |name|
+    get_remote(name)
+  end.compact.first
+end
+
+def get_remote(name)
+  parts = `git remote get-url #{name} 2>/dev/null`.match(/(\w+\/[\w-]+)(?:\.git)?$/)
+  parts[1] if parts
+end
+
 options = {}
 options[:oauth] = ENV['GITHUB_COMMUNITY_TOKEN'] if ENV['GITHUB_COMMUNITY_TOKEN']
 parser = OptionParser.new do |opts|
-  opts.banner = 'Usage: labels.rb [options]'
+  opts.banner = "Usage: labels.rb [options]
+       use only one of --file, --repo, --remote.
+
+"
   opts.on('-t', '--oauth-token TOKEN', 'OAuth token. Required.') { |v| options[:oauth] = v }
   opts.on('-f', '--fix-labels', 'Add the missing labels to repo') { options[:fix_labels] = true }
   opts.on('-d', '--delete-labels', 'Delete unwanted labels from repo') { options[:delete_labels] = true }
-  opts.on('-f', '--file NAME', String, 'Module file list') { |v| options[:file] = v }
+  opts.on('-f', '--file NAME', String, 'Module file list.') { |v| options[:file] = v }
+
+  opts.on('--repo [REPO]', 'Pass a repository name, defaults to the current upstream.') do |v|
+    options[:remote] = v || primary_remote
+    raise 'Could not guess primary remote. Try using --remote instead.' unless options[:remote]
+  end
+
+  opts.on('--remote REMOTE', 'Name of a remote to work on.') do |v|
+    options[:remote] = get_remote(v)
+    raise "No url set for remote #{v}" unless options[:remote]
+  end
 end
 
 parser.parse!
-options[:file] = 'modules.json' if options[:file].nil?
 
 missing = []
 missing << '-t' if options[:oauth].nil?
 unless missing.empty?
   puts "Missing options: #{missing.join(', ')}"
   puts parser
-  exit
+  exit 1
+end
+
+if options[:file].nil? and options [:remote].nil?
+  options[:file] = 'modules.json'
+elsif options[:file] and options[:remote]
+  puts 'Please pass only one of --file, --repo, or --remote'
+  puts parser
+  exit 1
 end
 
 util = OctokitUtils.new(options[:oauth])
+if options[:file]
+  parsed = util.load_module_list(options[:file])
+else
+  ns, r = options[:remote].split('/')
+  parsed = [{ 'github_namespace' => ns, 'repo_name' => r }]
+end
 
 wanted_labels = [{ name: 'needs-squash', color: 'bfe5bf' }, { name: 'needs-rebase', color: '3880ff' }, { name: 'needs-tests', color: 'ff8091' }, { name: 'needs-docs', color: '149380' }, { name: 'bugfix', color: '00d87b' }, { name: 'feature', color: '222222' }, { name: 'tests-fail', color: 'e11d21' }, { name: 'backwards-incompatible', color: 'd63700' }, { name: 'maintenance', color: 'ffd86e' }]
-parsed = util.load_module_list(options[:file])
 
 label_names = []
 wanted_labels.each do |wanted_label|


### PR DESCRIPTION
This allows you to add the proper labels to any given repository. For
example, one might use it to add labels to a newly created module
without adding to the IAC team's matrix.