### PR TITLE
Updated gruff gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,7 @@
 
 source 'https://rubygems.org'
 gem 'octokit'
-# gruff appears to have gone dormant. This allows it to install with current
-# rmagick, which fixes an imagemagick@6 pkg-config bug.
-# https://github.com/topfunky/gruff/pull/186
-gem 'gruff', github: 'Watson1978/gruff', branch: 'rmagick'
+gem 'gruff', '~> 0.12'
 
 group 'development' do
   gem 'pry'


### PR DESCRIPTION
Hello 👋 

I only have a need to use `labels.rb` here for maintaining the labels on ploperations modules, but when I tried to `bundle install` it failed because the `rmagick` branch in the gruff gem's fork at https://github.com/Watson1978/gruff was deleted about 1 year ago, since https://github.com/topfunky/gruff/pull/186 was merged.

So I changed this back to using the upstream gem, however I have not tested `graph.rb` where this is actually used.

Any suggestions or anything I can do to assist with this?


Thanks,
Jake